### PR TITLE
update GDC tests

### DIFF
--- a/global-services-testing/sections/testing/global-cache.adoc
+++ b/global-services-testing/sections/testing/global-cache.adoc
@@ -1,8 +1,8 @@
 [[global-cache-testing]]
 
-== Global Cache Service testing
+=== Global Cache Service testing
 
-=== Functional Tests
+==== Functional Tests
 
 ===== 1. MQTT Broker Connectivity
 
@@ -407,7 +407,7 @@ A Global Cache should treat notification messages with the same data item identi
     ** `wmo_wis2_gc_downloaded_errors_total` (unchanged)
     ** `wmo_wis2_gc_integrity_failed_total` (unchanged)
 
-=== Performance tests
+==== Performance tests
 
 ===== WIS2 Notification Processing Rate
 
@@ -494,7 +494,7 @@ The test is considered successful if the following conditions are met:
 * While the download time can be used to establish a baseline, it is highly dependent on the network and server conditions of the test environment and should not be used as a pass/fail criteria.
 
 
-=== Implicit tests
+==== Implicit tests
 These are tests that are to be verified by the individual implementations as they represent critical requirements but would be difficult to test in a generic way.
 
 ===== Valid TLS/SSL certificate

--- a/global-services-testing/sections/testing/global-discovery-catalogue.adoc
+++ b/global-services-testing/sections/testing/global-discovery-catalogue.adoc
@@ -249,7 +249,7 @@ Validate that a GDC initializes from a metadata archive zipfile.
 . Foreach WCMP2 (JSON) record in the zipfile, validate and ingest into the new GDC
 
 . Construct a path to a Global Replay service endpoint (`\https://HOST/collections/wis2-notification-messages?q=%22cache/a/wis2/*/metadata%22&datetime=START_TIME/..`).
-.. `START_TIME` is a timestamp that is from 24 hours ago, in RFC3339 format.
+.. `START_TIME` is a timestamp that is from up to 24 hours ago, in RFC3339 format.
 . Issue a HTTP GET request on the path.
 . Parse the HTTP response.
 . Foreach item in the `features` array:

--- a/global-services-testing/sections/testing/global-discovery-catalogue.adoc
+++ b/global-services-testing/sections/testing/global-discovery-catalogue.adoc
@@ -283,28 +283,26 @@ Validate that a GDC API performs as expected based on the OGC API - Records stan
 . In the `links` array, check that an items link is available (where a link object's `rel=items` and `type=application/geo+json`).
 . In the matching link, issue a HTTP GET request on the associated `href` value.
 . Parse the HTTP response.
-. Ensure that a `numberMatched` property exists with an integer value greater than 0.
-. Ensure that a `numberReturned` property exists with an integer value greater than 0.
+. Ensure that a `numberMatched` property exists with an integer value of 6.
+. Ensure that a `numberReturned` property exists with an integer value of 6.
 . Construct a path to the GDC endpoint with a bounding box query parameter (`\https://HOST/collections/wis2-discovery-metadata/items?bbox=-142,42,-53,84`).
 . Issue a HTTP GET request on the path.
 . Parse the HTTP response.
-. Ensure that a `numberMatched` property exists with an integer value greater than 0.
-. Ensure that a `numberReturned` property exists with an integer value greater than 0.
+. Ensure that a `numberMatched` property exists with an integer value of 2.
+. Ensure that a `numberReturned` property exists with an integer value of 2.
 . Ensure that a `features` array exists.
 . Construct a path to the GDC endpoint with a temporal query parameter (`\https://HOST/collections/wis2-discovery-metadata/items?datetime=2000-11-11T12:42:23Z/..`).
 . Issue a HTTP GET request on the path.
 . Parse the HTTP response.
-. Ensure that a `numberMatched` property exists with an integer value greater than 0.
-. Ensure that a `numberReturned` property exists with an integer value greater than 0.
+. Ensure that a `numberMatched` property exists with an integer value of 6.
+. Ensure that a `numberReturned` property exists with an integer value of 6.
 . Ensure that a `features` array exists.
 . Construct a path to the GDC endpoint with a full text query parameter (`\https://HOST/collections/wis2-discovery-metadata/items?q=observations`).
 . Issue a HTTP GET request on the path.
 . Parse the HTTP response.
-. Ensure that a `numberMatched` property exists with an integer value greater than 0.
-. Ensure that a `numberReturned` property exists with an integer value greater than 0.
+. Ensure that a `numberMatched` property exists with an integer value of 4.
+. Ensure that a `numberReturned` property exists with an integer value of 4.
 . Ensure that a `features` array exists.
-
-TODO: measure accuracy
 
 ==== Performance tests
 

--- a/global-services-testing/sections/testing/global-discovery-catalogue.adoc
+++ b/global-services-testing/sections/testing/global-discovery-catalogue.adoc
@@ -23,14 +23,14 @@ The GDC test setup consists of the following:
 
 A Global Discovery Catalogue must connect to a Global Broker using the MQTT protocol with TLS and username/password authentication (everyone/everyone) and subscribe to the following topic:
 
-* ``++origin/a/wis2/+/metadata/#++``
+* ``++cache/a/wis2/+/metadata/#++``
 
 ====== Steps
 
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . Close the connections to the broker after the test.
 
@@ -49,7 +49,7 @@ The Global Discovery Catalogue should be able to process valid WCMP2 metadata re
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . On an incoming message:
 .. find the canonical link object in the `links` array.
@@ -79,7 +79,7 @@ The Global Discovery Catalogue should be able to process failing (record not fou
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . On an incoming message:
 .. find the canonical link object in the `links` array.
@@ -104,7 +104,7 @@ The Global Discovery Catalogue should be able to process failing (malformed JSON
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . On an incoming message:
 .. find the canonical link object in the `links` array.
@@ -119,34 +119,7 @@ On successful completion:
 ** `wmo_wis2_gdc_failed_total` for the centre-id from where the metadata was published from should be incremented by 1 (one).
 * a notification message should arrive from the Global Broker under `monitor/a/wis2/CENTRE_ID_global-discovery-catalogue/centre-id`)
 
-====== Purpose
-
-The Global Discovery Catalogue should be able to process failing WCMP2 metadata published by a WIS2 Node.
-
-====== Steps
-
-. Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
-. Connect the MQTT client to the Global Broker.
-. Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
-. Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
-. On an incoming message:
-.. find the canonical link object in the `links` array.
-.. from the matching link, issue a HTTP GET request against the matching `href` value.
-.. parse the HTTP response:
-... validate against the WCMP2 Executable Test Suite (ETS)
-... publish an ETS error report as a notification message to the GDC MQTT broker.
-
-On successful completion:
-
-* the following metrics should be modified:
-** `wmo_wis2_gdc_failed_total` for the centre-id from where the metadata was published from should be incremented by 1 (one).
-* a notification message should arrive from the Global Broker under `monitor/a/wis2/CENTRE_ID_global-discovery-catalogue/centre-id`)
-
 ===== Metadata ingest centre-id mismatch
-
-TODO: validate workflow for regional distribution of partner metadata
-
 
 ====== Purpose
 
@@ -157,15 +130,19 @@ A Global Discovery Catalogue should detect a mismatch between an incoming messag
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . On an incoming message:
 .. capture the centre-id from the topic (4th token split on `/`).
 .. find the canonical link object in the `links` array.
 .. from the matching link, issue a HTTP GET request against the matching `href` value.
 .. parse the HTTP response:
-.. extract the centre-id from WCMP2 record identifier (3rd token split on `:`).
-. compare the centre-id from the topic and the centre-id of the WCMP2 record identifier.
+.. extract the centre-id from WCMP2 record identifier (`id` property, 3rd token split on `:`).
+.. in the WCMP2 record, if a MQTT link exists (`rel=items`, `channel` starts with `origin/a/wis2`), capture the centre-id from the topic (4th token split on `/`).
+. compare the following values to verify that they are identical:
+.. centre-id extracted from topic
+.. centre-id extracted from WCMP2 identifier
+.. centre-id extracted from MQTT link in WCMP2 record
 . publish an ETS error report as a notification message to the GDC MQTT broker.
 
 On successful completion, the following metrics should be modified:
@@ -184,7 +161,7 @@ The Global Discovery Catalogue should be able to process valid WCMP2 metadata re
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . On an incoming message:
 .. find the link object in the `links` array where `rel=deletion`.
@@ -215,7 +192,7 @@ The Global Discovery Catalogue should be able to detect a WNM error when `proper
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . On an incoming message:
 .. find the link object in the `links` array where `rel=deletion`.
@@ -252,7 +229,7 @@ Validate that a GDC API publishes a metadata archive zipfile.
 
 On successful completion:
 
-* the resulting HTTP response should be a zip encoded data, which, when unzipped, contains a directory of JSON files of WCMP2 metadata.
+* the resulting HTTP response should be zip encoded data, which, when unzipped, contains a directory of JSON files of WCMP2 metadata.
 
 ===== WCMP2 cold start initialization from metadata archive zipfile
 
@@ -271,7 +248,7 @@ Validate that a GDC initializes from a metadata archive zipfile.
 . Unzip the content of the HTTP response.
 . Foreach WCMP2 (JSON) record in the zipfile, validate and ingest into the new GDC
 
-. Construct a path to a Global Replay service endpoint (`\https://HOST/collections/wis2-notification-messages?topic=origin/a/wis2/*/metadata&datetime=START_TIME/..`).
+. Construct a path to a Global Replay service endpoint (`\https://HOST/collections/wis2-notification-messages?q=%22cache/a/wis2/*/metadata%22&datetime=START_TIME/..`).
 .. `START_TIME` is a timestamp that is from 24 hours ago, in RFC3339 format.
 . Issue a HTTP GET request on the path.
 . Parse the HTTP response.
@@ -281,35 +258,15 @@ Validate that a GDC initializes from a metadata archive zipfile.
 .. In the matching link, issue a HTTP GET request on the associated `href` value.
 .. Parse the HTTP response.
 .. Validate and ingest into the new GDC
-. Construct a path to the new GDC endpoint (`\https://HOST/collections/wis2-discovery-metadata/items?limit=99999`).
+. Construct a path to the new GDC endpoint (`\https://HOST/collections/wis2-discovery-metadata/items`).
 . Issue a HTTP GET request on the path.
 . Parse the HTTP response.
-. Count the numbe rof items in the `features` array.
+. Count the number of items in the `numberMatched` property.
 
 On successful completion:
 
 * the number of the features in the GDC should match the number of records in the metadata archive zipfile and the number of records from the Global Replay query.
 
-
-===== OpenMetrics publication
-
-====== Purpose
-
-Validate that a GDC API publishes an OpenMetrics endpoint.
-
-====== Steps
-
-. Construct a path to the GDC endpoint (`\https://HOST/collections/wis2-discovery-metadata`).
-. Issue a HTTP GET request on the path.
-. Parse the HTTP response.
-. Check that the record includes a `links` array.
-. In the `links` array, check that a metadata archive zipfile link is available (where a link object's `rel=related`, `type=text/plain` and `title=OpenMetrics`.
-. In the matching link, issue a HTTP GET request on the associated `href` value.
-. Parse the HTTP response.
-
-On successful completion:
-
-* the resulting HTTP response should be a text file in OpenMetrics format.
 
 ===== API functionality
 
@@ -362,7 +319,7 @@ Validate that a GDC is able to process WCMP2 metadata in a timely manner.
 . Initialize the MQTT client with the necessary parameters such as the MQTT protocol version 5, TLS security, and username/password for authentication.
 . Connect the MQTT client to the Global Broker.
 . Once the connection is successful, attempt to subscribe to the following topics:
-   - ``++origin/a/wis2/+/metadata/#++``
+   - ``++cache/a/wis2/+/metadata/#++``
 . Check if the subscription is successful. If the subscription is successful, proceed. If the subscription is not successful, the test fails.
 . On all incoming messages:
 .. find the canonical link object in the `links` array.

--- a/tests/global-discovery-catalogue/invalid/CentreId-mismatch.json
+++ b/tests/global-discovery-catalogue/invalid/CentreId-mismatch.json
@@ -1,0 +1,134 @@
+{
+    "id": "urn:wmo:md:ca-eccc-msc:climate.climate-daily",
+    "conformsTo": [
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
+    ],
+    "type": "Feature",
+	"geometry": {
+		"type": "Point",
+		"coordinates": [
+		132.9,
+		34.1
+		]
+	},    
+	"time": {
+        "interval": [
+            "1840-01-01",
+            ".."
+        ],
+        "resolution": "P1D"
+    },
+    "properties": {
+        "title": "Daily Climate Observations",
+        "description": "Daily climate observations are derived from two sources of data. The first are Daily Climate Stations producing one or two observations per day of temperature, precipitation. The second are hourly stations that typically produce more weather elements e.g. wind or snow on ground. Only a subset of the total stations is shown due to size limitations. The criteria for station selection are listed as below. The priorities for inclusion are as follows: (1) Station is currently operational, (2) Stations with long periods of record, (3) Stations that are co-located with the categories above and supplement the period of record.",
+        "themes": [
+            {
+                "concepts": [
+                    {
+                        "id": "Climate"
+                    },
+                    {
+                        "id": "Climate archives"
+                    },
+                    {
+                        "id": "Climate change"
+                    }
+                ],
+                "scheme": "https://canada.multites.net/cst"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "climate",
+                        "title": "Climate",
+                        "url": "https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline/climate"
+                    }
+                ],
+                "scheme": "https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+            }
+        ],
+        "contacts": [
+            {
+                "name": "National Inquiry Response Team",
+                "organization": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
+                "phones": [
+                    {
+                        "value": "+18199972800"
+                    }
+                ],
+                "emails": [
+                    {
+                        "value": "enviroinfo@ec.gc.ca"
+                    }
+                ],
+                "addresses": [
+                    {
+                        "deliveryPoint": [
+                            "77 Westmorland Street, suite 260"
+                        ],
+                        "city": "Fredericton",
+                        "administrativeArea": "NB",
+                        "postalCode": "E3B 6Z4",
+                        "country": "Canada"
+                    }
+                ],
+                "contactInstructions": "email",
+                "links": [
+                    {
+                        "rel": "canonical",
+                        "type": "text/html",
+                        "href": "https://www.canada.ca/en/environment-climate-change.html"
+                    }
+                ],
+                "roles": [
+                    "host",
+                    "producer"
+                ]
+            }
+        ],
+		"type": "dataset",
+        "language": "en",
+        "created": "2018-01-01T21:11:12Z",
+        "updated": "2022-06-17T18:43:39Z",
+		"wmo:dataPolicy": "core"
+    },
+    "links": [
+        {
+            "rel": "stations",
+            "href": "https://api.weather.gc.ca/collections/climate-stations/items",
+            "type": "application/geo+json",
+            "title": "Stations associated with this dataset"
+        },
+        {
+            "rel": "data",
+            "href": "https://dd.weather.gc.ca/climate/observations/daily/csv",
+            "type": "text/html",
+            "title": "Raw data download (CSV files)"
+        },
+        {
+            "rel": "license",
+            "href": "https://open.canada.ca/en/open-government-licence-canada",
+            "type": "text/html",
+            "title": "Open Government Licence - Canada"
+        },
+        {
+            "rel": "items",
+            "href": "https://api.weather.gc.ca/collections/climate-daily/items",
+            "type": "application/geo+json",
+            "title": "Climate daily data access API interface"
+        },
+        {
+            "rel": "related",
+            "href": "https://eccc-msc.github.io/open-data/msc-data/climate_obs/readme_climateobs_en",
+            "type": "text/html",
+            "title": "Documentation"
+        },
+        {
+            "rel": "items",
+            "href": "mqtts://example.org",
+            "channel": "origin/a/wis2/ar-smn/data/core/climate",
+            "type": "application/geo+json",
+            "title": "Data notifications"
+        }
+    ]
+}

--- a/tests/global-discovery-catalogue/valid/urnwmomdcn-cmadata.core.weather.prediction.forecast.shortrange.probabilistic.global.json
+++ b/tests/global-discovery-catalogue/valid/urnwmomdcn-cmadata.core.weather.prediction.forecast.shortrange.probabilistic.global.json
@@ -95,8 +95,7 @@
 					}
 				],
 				"roles":[
-					"pointOfContact",
-					"distributor"
+					"host"
 				]
 			}
 		],

--- a/tests/global-discovery-catalogue/valid/urnwmomdcn-cmadata.core.weather.space-based-observations.fy-3e.gnos-2.json
+++ b/tests/global-discovery-catalogue/valid/urnwmomdcn-cmadata.core.weather.space-based-observations.fy-3e.gnos-2.json
@@ -96,8 +96,7 @@
 					}
 				],
 				"roles":[
-					"pointOfContact",
-					"distributor"
+					"host"
 				]
 			},
 			{

--- a/tests/global-discovery-catalogue/valid/urnwmomdcn-cmadata.core.weather.surface-based-observations.json
+++ b/tests/global-discovery-catalogue/valid/urnwmomdcn-cmadata.core.weather.surface-based-observations.json
@@ -95,8 +95,7 @@
 					}
 				],
 				"roles":[
-					"pointOfContact",
-					"distributor"
+					"host"
 				]
 			}
 		],


### PR DESCRIPTION
This PR updates GDC tests as follows:
- update GB topic subscription
- fixes valid metadata that did not pass ETS
- add centre-id mismatch test
- remove duplicate test
- add precision to GDC API results test assertions