### PR TITLE
change paho and pywispubsub versions

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
-paho-mqtt
+paho-mqtt~=2.1.0
 prometheus_api_client
 pytest
 python-dotenv
 python-slugify
-pywis-pubsub
+git+https://github.com/wmo-im/pywis-pubsub.git@main#egg=pywis-pubsub


### PR DESCRIPTION
recommend using pip install --force-reinstall --no-cache-dir -r requirements.txt

officially adopt paho-mqtt 2x