### PR TITLE
Adding sections to 04-testing.adoc

### DIFF
--- a/global-services-testing/sections/04-testing.adoc
+++ b/global-services-testing/sections/04-testing.adoc
@@ -125,3 +125,9 @@ include::testing/global-broker.adoc[]
 include::testing/global-cache.adoc[]
 
 include::testing/global-discovery-catalogue.adoc[]
+
+include::testing/global-monitor.adoc[]
+
+include::testing/gts-to-wis2-gateway.adoc[]
+
+include::testing/wis2-to-gts-gateway.adoc[]


### PR DESCRIPTION
Added includes for
- testing/global-monitor.adoc
- testing/gts-to-wis2-gateway.adoc (see PR #72)
- testing/wis2-to-gts-gateway.adoc (see PR #73)